### PR TITLE
feat(forward): add IPv4/IPv6 listen stack selection with dual-stack default

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -18,6 +18,10 @@ forward:
   maxport: 60000
   userandom: true
   reserved: []
+  # 转发监听默认使用的 IP 协议栈:dual(默认,同时监听 IPv4+IPv6)/ ipv4 / ipv6。
+  # 未设置时按 dual 处理;单条转发规则可通过 listen_addr / listen_stack 覆盖。
+  # 注意 key 必须带下划线(loader 按结构体 yaml tag 解析)。
+  listen_stack: dual
 
 cert_mgmt:
   email: ""

--- a/pkg/proxy/appconfig/loader.go
+++ b/pkg/proxy/appconfig/loader.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lureiny/v2raymg/pkg/proxy/core/container"
 	"github.com/lureiny/v2raymg/pkg/proxy/core/contracts"
+	"github.com/lureiny/v2raymg/pkg/proxy/forward"
 	"gopkg.in/yaml.v3"
 )
 
@@ -131,6 +132,7 @@ func defaultAppConfig() *AppConfig {
 	cfg.Store.DSN = "./v2raymg.db"
 	cfg.Forward.MinPort = 10000
 	cfg.Forward.MaxPort = 60000
+	cfg.Forward.ListenStack = forward.ListenStackDual
 	cfg.EndNode.Ping.EnableICMPPing = true
 	cfg.EndNode.Ping.ICMPPingInterval = 5
 	cfg.EndNode.Ping.ICMPPingTimeout = 1
@@ -252,6 +254,14 @@ func Validate(cfg *AppConfig) error {
 	if cfg.Forward.MinPort >= cfg.Forward.MaxPort {
 		return fmt.Errorf("appconfig: forward.min_port (%d) must be less than forward.max_port (%d)",
 			cfg.Forward.MinPort, cfg.Forward.MaxPort)
+	}
+
+	switch strings.ToLower(strings.TrimSpace(cfg.Forward.ListenStack)) {
+	case "", forward.ListenStackDual, forward.ListenStackIPv4, forward.ListenStackIPv6:
+		// ok
+	default:
+		return fmt.Errorf("appconfig: forward.listen_stack %q is invalid; valid values are %q, %q, %q",
+			cfg.Forward.ListenStack, forward.ListenStackDual, forward.ListenStackIPv4, forward.ListenStackIPv6)
 	}
 
 	if cfg.CertMgmt.Email != "" && !strings.Contains(cfg.CertMgmt.Email, "@") {

--- a/pkg/proxy/forward/forward_manager.go
+++ b/pkg/proxy/forward/forward_manager.go
@@ -27,6 +27,17 @@ func WithPortRange(minPort, maxPort uint32) ForwardManagerOption {
 	}
 }
 
+// WithListenStack sets the default IP stack for wildcard forward listeners:
+// "dual" (default), "ipv4", or "ipv6". Unrecognized values are ignored.
+// Individual rules may override via ForwardRule.ListenStack.
+func WithListenStack(stack string) ForwardManagerOption {
+	return func(m *DefaultForwardManager) {
+		if s := normalizeListenStack(stack); s != "" {
+			m.defaultListenStack = s
+		}
+	}
+}
+
 // NewForwardManager creates a new ForwardManager with options.
 // If no options are provided, default port range is 10000-65535 with random allocation.
 func NewForwardManager(opts ...ForwardManagerOption) (*DefaultForwardManager, error) {
@@ -48,6 +59,7 @@ func NewForwardManager(opts ...ForwardManagerOption) (*DefaultForwardManager, er
 		userBandwidth:          make(map[string]*userBandwidthLimiter),
 		userClientLimiters:     make(map[string]ClientLimiter),
 		userClientLimitConfigs: make(map[string]ClientLimitConfig),
+		defaultListenStack:     ListenStackDual,
 	}
 
 	// Apply options
@@ -88,6 +100,9 @@ type DefaultForwardManager struct {
 	userBandwidth         map[string]*userBandwidthLimiter // key = username
 	userClientLimiters    map[string]ClientLimiter       // key = username, active limiter instances
 	userClientLimitConfigs map[string]ClientLimitConfig  // key = username, stored config (may have no active limiter)
+	// defaultListenStack is the fallback IP stack for wildcard listeners when a
+	// rule does not set ForwardRule.ListenStack: "dual" (default), "ipv4", or "ipv6".
+	defaultListenStack string
 }
 
 // NewDefaultForwardManager creates a new ForwardManager with the given port allocator config.
@@ -109,6 +124,11 @@ func NewDefaultForwardManager(allocCfg PortAllocatorConfig) (*DefaultForwardMana
 		return nil, fmt.Errorf("forward_manager: %w", err)
 	}
 
+	listenStack := normalizeListenStack(allocCfg.ListenStack)
+	if listenStack == "" {
+		listenStack = ListenStackDual
+	}
+
 	return &DefaultForwardManager{
 		allocator:              alloc,
 		traffic:                NewTrafficRegistry(),
@@ -116,6 +136,7 @@ func NewDefaultForwardManager(allocCfg PortAllocatorConfig) (*DefaultForwardMana
 		userBandwidth:          make(map[string]*userBandwidthLimiter),
 		userClientLimiters:     make(map[string]ClientLimiter),
 		userClientLimitConfigs: make(map[string]ClientLimitConfig),
+		defaultListenStack:     listenStack,
 	}, nil
 }
 
@@ -187,12 +208,16 @@ func (m *DefaultForwardManager) AddRule(rule ForwardRule) (*ForwardRule, error) 
 	limiterUp = userLimiter.UploadLimiter()
 	limiterDown = userLimiter.DownloadLimiter()
 
-	// Determine listen address
-	listenAddr := rule.ListenAddr
-	if listenAddr == "" {
-		listenAddr = "0.0.0.0"
+	// Resolve the set of sockets to bind for this rule. A specific ListenAddr or
+	// a single-stack wildcard yields one endpoint; the default dual-stack yields
+	// two (IPv4 wildcard + best-effort IPv6 wildcard).
+	endpoints, err := resolveListenEndpoints(rule.ListenAddr, rule.ListenStack, m.defaultListenStack, port)
+	if err != nil {
+		m.allocator.Release(port)
+		m.traffic.Remove(key)
+		return nil, fmt.Errorf("forward_manager: %w", err)
 	}
-	fullListenAddr := fmt.Sprintf("%s:%d", listenAddr, port)
+	listenDesc := describeEndpoints(endpoints)
 
 	// Determine effective client limit config with priority: rule > stored config > default
 	var effectiveMaxClients int
@@ -264,37 +289,56 @@ func (m *DefaultForwardManager) AddRule(rule ForwardRule) (*ForwardRule, error) 
 		}
 	}
 
-	// Create and start relay, dispatched by network kind.
+	// buildRelay constructs a relay for one bind endpoint. All endpoints of the
+	// same rule share the counter and user-level limiters, so traffic counting
+	// and client limits treat the (possibly dual-stack) rule as one unit.
+	buildRelay := func(ep listenEndpoint) Relay {
+		switch rule.ResolvedNetwork() {
+		case NetworkUDP:
+			idle := time.Duration(rule.UDPSessionIdleSec) * time.Second
+			return NewUDPRelay(UDPRelayConfig{
+				ListenAddr:         ep.address,
+				V6Only:             ep.v6only,
+				TargetAddr:         rule.TargetAddr,
+				Counter:            counter,
+				LimiterUp:          limiterUp,
+				LimiterDown:        limiterDown,
+				MaxSessions:        rule.MaxConnections,
+				ClientLimiter:      clientLimiter,
+				SessionIdleTimeout: idle,
+			})
+		default:
+			return NewTCPRelay(TCPRelayConfig{
+				ListenAddr:    ep.address,
+				V6Only:        ep.v6only,
+				TargetAddr:    rule.TargetAddr,
+				Counter:       counter,
+				LimiterUp:     limiterUp,
+				LimiterDown:   limiterDown,
+				MaxConns:      rule.MaxConnections,
+				ClientLimiter: clientLimiter,
+			})
+		}
+	}
+
+	// A single endpoint uses a plain relay (bind failure is fatal). Multiple
+	// endpoints (dual-stack) use a multiRelay so the best-effort IPv6 half can
+	// be skipped on IPv6-disabled hosts without failing the rule.
 	var relay Relay
-	switch rule.ResolvedNetwork() {
-	case NetworkUDP:
-		idle := time.Duration(rule.UDPSessionIdleSec) * time.Second
-		relay = NewUDPRelay(UDPRelayConfig{
-			ListenAddr:         fullListenAddr,
-			TargetAddr:         rule.TargetAddr,
-			Counter:            counter,
-			LimiterUp:          limiterUp,
-			LimiterDown:        limiterDown,
-			MaxSessions:        rule.MaxConnections,
-			ClientLimiter:      clientLimiter,
-			SessionIdleTimeout: idle,
-		})
-	default:
-		relay = NewTCPRelay(TCPRelayConfig{
-			ListenAddr:    fullListenAddr,
-			TargetAddr:    rule.TargetAddr,
-			Counter:       counter,
-			LimiterUp:     limiterUp,
-			LimiterDown:   limiterDown,
-			MaxConns:      rule.MaxConnections,
-			ClientLimiter: clientLimiter,
-		})
+	if len(endpoints) == 1 {
+		relay = buildRelay(endpoints[0])
+	} else {
+		children := make([]relayChild, 0, len(endpoints))
+		for _, ep := range endpoints {
+			children = append(children, relayChild{relay: buildRelay(ep), optional: ep.optional})
+		}
+		relay = newMultiRelay(children)
 	}
 
 	if err := relay.Start(); err != nil {
 		m.allocator.Release(port)
 		m.traffic.Remove(key)
-		log.Debug("[ForwardManager] relay start failed", "key", key, "listen", fullListenAddr, "target", rule.TargetAddr, "network", rule.ResolvedNetwork(), "err", err)
+		log.Debug("[ForwardManager] relay start failed", "key", key, "listen", listenDesc, "target", rule.TargetAddr, "network", rule.ResolvedNetwork(), "err", err)
 		return nil, fmt.Errorf("forward_manager: relay start: %w", err)
 	}
 
@@ -306,7 +350,7 @@ func (m *DefaultForwardManager) AddRule(rule ForwardRule) (*ForwardRule, error) 
 		clientLimiter:     clientLimiter,
 	}
 
-	log.Info("[ForwardManager] rule added", "key", key, "listen", fullListenAddr, "target", rule.TargetAddr, "user", rule.Username)
+	log.Info("[ForwardManager] rule added", "key", key, "listen", relay.ListenAddr(), "target", rule.TargetAddr, "user", rule.Username)
 
 	result := rule // copy
 	return &result, nil

--- a/pkg/proxy/forward/forward_manager.go
+++ b/pkg/proxy/forward/forward_manager.go
@@ -298,7 +298,7 @@ func (m *DefaultForwardManager) AddRule(rule ForwardRule) (*ForwardRule, error) 
 			idle := time.Duration(rule.UDPSessionIdleSec) * time.Second
 			return NewUDPRelay(UDPRelayConfig{
 				ListenAddr:         ep.address,
-				V6Only:             ep.v6only,
+				Family:             ep.family,
 				TargetAddr:         rule.TargetAddr,
 				Counter:            counter,
 				LimiterUp:          limiterUp,
@@ -310,7 +310,7 @@ func (m *DefaultForwardManager) AddRule(rule ForwardRule) (*ForwardRule, error) 
 		default:
 			return NewTCPRelay(TCPRelayConfig{
 				ListenAddr:    ep.address,
-				V6Only:        ep.v6only,
+				Family:        ep.family,
 				TargetAddr:    rule.TargetAddr,
 				Counter:       counter,
 				LimiterUp:     limiterUp,

--- a/pkg/proxy/forward/forward_manager_test.go
+++ b/pkg/proxy/forward/forward_manager_test.go
@@ -628,16 +628,16 @@ func TestForwardManager_AddRule_UDPDispatch(t *testing.T) {
 		t.Fatalf("AddRule udp: %v", err)
 	}
 
-	// The managed relay must be a UDPRelay, not a TCPRelay.
+	// The managed relay must be UDP, not TCP. Under the default dual-stack
+	// listener the relay is a *multiRelay wrapping one UDPRelay per bound
+	// socket, so unwrap before asserting the concrete transport type.
 	m.mu.RLock()
 	mr := m.rules[created.RuleKey()]
 	m.mu.RUnlock()
 	if mr == nil {
 		t.Fatal("managedRule missing")
 	}
-	if _, ok := mr.relay.(*UDPRelay); !ok {
-		t.Fatalf("expected *UDPRelay, got %T", mr.relay)
-	}
+	assertUDPRelay(t, mr.relay)
 
 	// Round-trip a datagram via the allocated port.
 	client := dialUDP(t, fmt.Sprintf("127.0.0.1:%d", created.ListenPort))

--- a/pkg/proxy/forward/listen.go
+++ b/pkg/proxy/forward/listen.go
@@ -15,11 +15,15 @@ type listenEndpoint struct {
 	// address is a "host:port" string, already bracketed for IPv6 literals
 	// (produced by net.JoinHostPort), suitable for net.Listen / net.ListenPacket.
 	address string
-	// v6only requests IPV6_V6ONLY on the socket. Set for the "[::]" wildcard so
-	// it can coexist with a sibling "0.0.0.0" socket on the same port without an
-	// address-in-use conflict, and so IPv4 clients keep their real (non
-	// v4-mapped) source addresses.
-	v6only bool
+	// family pins the socket's address family via the network suffix:
+	// "" -> "tcp"/"udp" (family inferred from a specific IP literal),
+	// "4" -> "tcp4"/"udp4" (real AF_INET), "6" -> "tcp6"/"udp6" (AF_INET6, which
+	// Go binds with IPV6_V6ONLY=1). Pinning matters for wildcards: a bare
+	// net.Listen("tcp","0.0.0.0:p") is promoted by Go to a dual-stack AF_INET6
+	// socket, so "ipv4" would wrongly also accept IPv6 and would collide with a
+	// sibling "[::]" bind. "4"+"6" give two clean, non-overlapping sockets with
+	// real (non v4-mapped) client addresses on each.
+	family string
 	// optional marks a best-effort endpoint: if binding fails (e.g. the host
 	// lacks one IP family), the failure is logged and the endpoint skipped
 	// instead of failing the whole rule. BOTH halves of a dual-stack listener
@@ -59,34 +63,48 @@ func firstListenStack(candidates ...string) string {
 // resolveListenEndpoints computes the set of sockets to bind for a rule.
 //
 //   - A non-empty listenAddr (a specific IP literal) yields exactly one socket
-//     bound to that address; ruleStack/defaultStack are ignored.
+//     bound to that address; ruleStack/defaultStack are ignored. A wildcard
+//     literal ("0.0.0.0" / "::") is family-pinned so it stays single-stack.
 //   - An empty listenAddr yields a wildcard listener governed by the effective
 //     stack (rule override, else manager default, else dual):
-//     "ipv4" -> [0.0.0.0], "ipv6" -> [[::] v6only],
-//     "dual" -> [0.0.0.0, [::] v6only] with BOTH best-effort (a host missing
+//     "ipv4" -> [0.0.0.0 tcp4], "ipv6" -> [[::] tcp6],
+//     "dual" -> [0.0.0.0 tcp4, [::] tcp6] with BOTH best-effort (a host missing
 //     either family skips that half; the rule fails only if neither binds).
 func resolveListenEndpoints(listenAddr, ruleStack, defaultStack string, port uint32) ([]listenEndpoint, error) {
 	p := strconv.Itoa(int(port))
 
 	if addr := strings.TrimSpace(listenAddr); addr != "" {
-		if net.ParseIP(addr) == nil {
+		ip := net.ParseIP(addr)
+		if ip == nil {
 			return nil, fmt.Errorf("listen_addr %q is not a valid IP literal", addr)
 		}
-		return []listenEndpoint{{address: net.JoinHostPort(addr, p)}}, nil
+		// A specific (non-wildcard) address is bound as-is with an inferred
+		// family. An explicit wildcard literal is pinned so it does not get
+		// promoted to a dual-stack socket by net.Listen.
+		family := ""
+		if ip.IsUnspecified() {
+			if ip.To4() != nil {
+				family = "4"
+			} else {
+				family = "6"
+			}
+		}
+		return []listenEndpoint{{address: net.JoinHostPort(addr, p), family: family}}, nil
 	}
 
 	switch firstListenStack(ruleStack, defaultStack) {
 	case ListenStackIPv4:
-		return []listenEndpoint{{address: net.JoinHostPort("0.0.0.0", p)}}, nil
+		return []listenEndpoint{{address: net.JoinHostPort("0.0.0.0", p), family: "4"}}, nil
 	case ListenStackIPv6:
-		return []listenEndpoint{{address: net.JoinHostPort("::", p), v6only: true}}, nil
+		return []listenEndpoint{{address: net.JoinHostPort("::", p), family: "6"}}, nil
 	default: // dual
-		// Both halves are best-effort: a host with only IPv4 skips the [::]
-		// bind, a host with only IPv6 skips the 0.0.0.0 bind. multiRelay.Start
-		// still fails the rule if NEITHER family binds.
+		// Two clean sockets (real AF_INET + AF_INET6/V6ONLY). Both are
+		// best-effort: a host with only IPv4 skips the [::] bind, a host with
+		// only IPv6 skips the 0.0.0.0 bind. multiRelay.Start still fails the
+		// rule if NEITHER family binds.
 		return []listenEndpoint{
-			{address: net.JoinHostPort("0.0.0.0", p), optional: true},
-			{address: net.JoinHostPort("::", p), v6only: true, optional: true},
+			{address: net.JoinHostPort("0.0.0.0", p), family: "4", optional: true},
+			{address: net.JoinHostPort("::", p), family: "6", optional: true},
 		}, nil
 	}
 }
@@ -101,24 +119,15 @@ func describeEndpoints(eps []listenEndpoint) string {
 	return strings.Join(parts, ",")
 }
 
-// listenTCP binds a TCP listener on address. When v6only is true it uses the
-// "tcp6" network so Go sets IPV6_V6ONLY on the socket; this lets an IPv6
-// wildcard ("[::]") coexist with a sibling IPv4 wildcard ("0.0.0.0") on the
-// same port and keeps IPv4 clients' real (non v4-mapped) source addresses.
-func listenTCP(address string, v6only bool) (net.Listener, error) {
-	network := "tcp"
-	if v6only {
-		network = "tcp6"
-	}
-	return net.Listen(network, address)
+// listenTCP binds a TCP listener on address using the "tcp"+family network
+// ("tcp", "tcp4", or "tcp6"). See listenEndpoint.family for why the family is
+// pinned for wildcard binds.
+func listenTCP(address, family string) (net.Listener, error) {
+	return net.Listen("tcp"+family, address)
 }
 
-// listenUDP binds a UDP packet connection on address, using "udp6" (IPV6_V6ONLY)
-// when v6only is requested. See listenTCP for the rationale.
-func listenUDP(address string, v6only bool) (net.PacketConn, error) {
-	network := "udp"
-	if v6only {
-		network = "udp6"
-	}
-	return net.ListenPacket(network, address)
+// listenUDP binds a UDP packet connection on address using the "udp"+family
+// network ("udp", "udp4", or "udp6").
+func listenUDP(address, family string) (net.PacketConn, error) {
+	return net.ListenPacket("udp"+family, address)
 }

--- a/pkg/proxy/forward/listen.go
+++ b/pkg/proxy/forward/listen.go
@@ -1,0 +1,124 @@
+package forward
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// listenEndpoint describes a single socket to bind for a forward rule.
+//
+// A rule resolves to one endpoint (a specific IP, or a single-stack wildcard)
+// or two endpoints (dual-stack: the IPv4 wildcard plus the IPv6 wildcard).
+type listenEndpoint struct {
+	// address is a "host:port" string, already bracketed for IPv6 literals
+	// (produced by net.JoinHostPort), suitable for net.Listen / net.ListenPacket.
+	address string
+	// v6only requests IPV6_V6ONLY on the socket. Set for the "[::]" wildcard so
+	// it can coexist with a sibling "0.0.0.0" socket on the same port without an
+	// address-in-use conflict, and so IPv4 clients keep their real (non
+	// v4-mapped) source addresses.
+	v6only bool
+	// optional marks a best-effort endpoint: if binding fails (e.g. the host
+	// lacks one IP family), the failure is logged and the endpoint skipped
+	// instead of failing the whole rule. BOTH halves of a dual-stack listener
+	// are optional (so an IPv4-only or IPv6-only host still comes up on the
+	// family it has); explicit single-stack / specific-IP listeners are always
+	// required. multiRelay.Start fails only if every endpoint is optional AND
+	// none of them bind.
+	optional bool
+}
+
+// normalizeListenStack canonicalizes a stack selector, returning "" for empty
+// or unrecognized input so callers can fall through to the next default.
+func normalizeListenStack(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case ListenStackIPv4, "v4":
+		return ListenStackIPv4
+	case ListenStackIPv6, "v6":
+		return ListenStackIPv6
+	case ListenStackDual, "both":
+		return ListenStackDual
+	default:
+		return ""
+	}
+}
+
+// firstListenStack returns the first recognized stack among the candidates,
+// defaulting to dual-stack when none is set.
+func firstListenStack(candidates ...string) string {
+	for _, c := range candidates {
+		if s := normalizeListenStack(c); s != "" {
+			return s
+		}
+	}
+	return ListenStackDual
+}
+
+// resolveListenEndpoints computes the set of sockets to bind for a rule.
+//
+//   - A non-empty listenAddr (a specific IP literal) yields exactly one socket
+//     bound to that address; ruleStack/defaultStack are ignored.
+//   - An empty listenAddr yields a wildcard listener governed by the effective
+//     stack (rule override, else manager default, else dual):
+//     "ipv4" -> [0.0.0.0], "ipv6" -> [[::] v6only],
+//     "dual" -> [0.0.0.0, [::] v6only] with BOTH best-effort (a host missing
+//     either family skips that half; the rule fails only if neither binds).
+func resolveListenEndpoints(listenAddr, ruleStack, defaultStack string, port uint32) ([]listenEndpoint, error) {
+	p := strconv.Itoa(int(port))
+
+	if addr := strings.TrimSpace(listenAddr); addr != "" {
+		if net.ParseIP(addr) == nil {
+			return nil, fmt.Errorf("listen_addr %q is not a valid IP literal", addr)
+		}
+		return []listenEndpoint{{address: net.JoinHostPort(addr, p)}}, nil
+	}
+
+	switch firstListenStack(ruleStack, defaultStack) {
+	case ListenStackIPv4:
+		return []listenEndpoint{{address: net.JoinHostPort("0.0.0.0", p)}}, nil
+	case ListenStackIPv6:
+		return []listenEndpoint{{address: net.JoinHostPort("::", p), v6only: true}}, nil
+	default: // dual
+		// Both halves are best-effort: a host with only IPv4 skips the [::]
+		// bind, a host with only IPv6 skips the 0.0.0.0 bind. multiRelay.Start
+		// still fails the rule if NEITHER family binds.
+		return []listenEndpoint{
+			{address: net.JoinHostPort("0.0.0.0", p), optional: true},
+			{address: net.JoinHostPort("::", p), v6only: true, optional: true},
+		}, nil
+	}
+}
+
+// describeEndpoints renders the endpoint addresses as a comma-joined string for
+// log messages (e.g. "0.0.0.0:12345,[::]:12345").
+func describeEndpoints(eps []listenEndpoint) string {
+	parts := make([]string, 0, len(eps))
+	for _, e := range eps {
+		parts = append(parts, e.address)
+	}
+	return strings.Join(parts, ",")
+}
+
+// listenTCP binds a TCP listener on address. When v6only is true it uses the
+// "tcp6" network so Go sets IPV6_V6ONLY on the socket; this lets an IPv6
+// wildcard ("[::]") coexist with a sibling IPv4 wildcard ("0.0.0.0") on the
+// same port and keeps IPv4 clients' real (non v4-mapped) source addresses.
+func listenTCP(address string, v6only bool) (net.Listener, error) {
+	network := "tcp"
+	if v6only {
+		network = "tcp6"
+	}
+	return net.Listen(network, address)
+}
+
+// listenUDP binds a UDP packet connection on address, using "udp6" (IPV6_V6ONLY)
+// when v6only is requested. See listenTCP for the rationale.
+func listenUDP(address string, v6only bool) (net.PacketConn, error) {
+	network := "udp"
+	if v6only {
+		network = "udp6"
+	}
+	return net.ListenPacket(network, address)
+}

--- a/pkg/proxy/forward/listen_test.go
+++ b/pkg/proxy/forward/listen_test.go
@@ -1,0 +1,278 @@
+package forward
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// relayServesPort reports whether the relay's bound address(es) include port.
+// The wildcard IP form (0.0.0.0 vs [::]) is host-dependent — some namespaces
+// collapse an IPv4 wildcard bind onto a dual-stack IPv6 socket — so tests assert
+// on the port and relay type rather than the exact wildcard address string.
+func relayServesPort(r Relay, port uint32) bool {
+	return strings.Contains(r.ListenAddr(), fmt.Sprintf(":%d", port))
+}
+
+// assertUDPRelay asserts that r forwards over UDP, transparently unwrapping the
+// dual-stack *multiRelay (each child must itself be a *UDPRelay).
+func assertUDPRelay(t *testing.T, r Relay) {
+	t.Helper()
+	switch v := r.(type) {
+	case *UDPRelay:
+		return
+	case *multiRelay:
+		if len(v.children) == 0 {
+			t.Fatal("multiRelay has no children")
+		}
+		for _, c := range v.children {
+			if _, ok := c.relay.(*UDPRelay); !ok {
+				t.Fatalf("expected *UDPRelay child, got %T", c.relay)
+			}
+		}
+	default:
+		t.Fatalf("expected *UDPRelay or *multiRelay, got %T", r)
+	}
+}
+
+// ipv6WildcardBindable reports whether the host can bind an IPv6 wildcard
+// listener. Some CI/sandbox network namespaces cannot, so IPv6-dependent tests
+// skip when this is false.
+func ipv6WildcardBindable() bool {
+	l, err := net.Listen("tcp6", "[::]:0")
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+func TestNormalizeListenStack(t *testing.T) {
+	cases := map[string]string{
+		"":      "",
+		"  ":    "",
+		"dual":  ListenStackDual,
+		"DUAL":  ListenStackDual,
+		"both":  ListenStackDual,
+		"ipv4":  ListenStackIPv4,
+		"v4":    ListenStackIPv4,
+		"IPv6":  ListenStackIPv6,
+		"v6":    ListenStackIPv6,
+		"bogus": "",
+		"ipv4x": "",
+	}
+	for in, want := range cases {
+		if got := normalizeListenStack(in); got != want {
+			t.Errorf("normalizeListenStack(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFirstListenStack(t *testing.T) {
+	if got := firstListenStack("", ""); got != ListenStackDual {
+		t.Errorf("all-empty => %q, want dual", got)
+	}
+	if got := firstListenStack("", "ipv4"); got != ListenStackIPv4 {
+		t.Errorf("fallback to default => %q, want ipv4", got)
+	}
+	if got := firstListenStack("ipv6", "ipv4"); got != ListenStackIPv6 {
+		t.Errorf("rule overrides default => %q, want ipv6", got)
+	}
+	if got := firstListenStack("bogus", "ipv4"); got != ListenStackIPv4 {
+		t.Errorf("unrecognized rule falls through => %q, want ipv4", got)
+	}
+}
+
+func TestResolveListenEndpoints(t *testing.T) {
+	cases := []struct {
+		name         string
+		listenAddr   string
+		ruleStack    string
+		defaultStack string
+		port         uint32
+		want         []listenEndpoint
+		wantErr      bool
+	}{
+		{
+			name:       "specific ipv4",
+			listenAddr: "10.0.0.5",
+			port:       8080,
+			want:       []listenEndpoint{{address: "10.0.0.5:8080"}},
+		},
+		{
+			name:       "specific ipv6 is bracketed",
+			listenAddr: "2001:db8::1",
+			port:       8080,
+			want:       []listenEndpoint{{address: "[2001:db8::1]:8080"}},
+		},
+		{
+			name: "empty inherits default dual, both best-effort",
+			port: 9000,
+			want: []listenEndpoint{
+				{address: "0.0.0.0:9000", optional: true},
+				{address: "[::]:9000", v6only: true, optional: true},
+			},
+		},
+		{
+			name:      "rule ipv4 only",
+			ruleStack: ListenStackIPv4,
+			port:      9000,
+			want:      []listenEndpoint{{address: "0.0.0.0:9000"}},
+		},
+		{
+			name:      "rule ipv6 only is v6only",
+			ruleStack: ListenStackIPv6,
+			port:      9000,
+			want:      []listenEndpoint{{address: "[::]:9000", v6only: true}},
+		},
+		{
+			name:         "default ipv4 applies when rule unset",
+			defaultStack: ListenStackIPv4,
+			port:         9000,
+			want:         []listenEndpoint{{address: "0.0.0.0:9000"}},
+		},
+		{
+			name:         "rule overrides default",
+			ruleStack:    ListenStackIPv6,
+			defaultStack: ListenStackIPv4,
+			port:         9000,
+			want:         []listenEndpoint{{address: "[::]:9000", v6only: true}},
+		},
+		{
+			name:       "specific address ignores stack",
+			listenAddr: "127.0.0.1",
+			ruleStack:  ListenStackIPv6,
+			port:       9000,
+			want:       []listenEndpoint{{address: "127.0.0.1:9000"}},
+		},
+		{
+			name:       "invalid listen addr errors",
+			listenAddr: "not-an-ip",
+			port:       9000,
+			wantErr:    true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveListenEndpoints(c.listenAddr, c.ruleStack, c.defaultStack, c.port)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("endpoints = %+v, want %+v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestValidate_ListenFields(t *testing.T) {
+	base := func() ForwardRule {
+		return ForwardRule{Username: "u@t.com", TargetAddr: "127.0.0.1:443"}
+	}
+
+	valid := []ForwardRule{
+		func() ForwardRule { r := base(); return r }(),
+		func() ForwardRule { r := base(); r.ListenStack = "ipv4"; return r }(),
+		func() ForwardRule { r := base(); r.ListenStack = "IPv6"; return r }(),
+		func() ForwardRule { r := base(); r.ListenStack = "dual"; return r }(),
+		func() ForwardRule { r := base(); r.ListenAddr = "192.168.1.1"; return r }(),
+		func() ForwardRule { r := base(); r.ListenAddr = "2001:db8::1"; return r }(),
+	}
+	for i, r := range valid {
+		if err := r.Validate(); err != nil {
+			t.Errorf("valid[%d] unexpected error: %v", i, err)
+		}
+	}
+
+	invalid := []ForwardRule{
+		func() ForwardRule { r := base(); r.ListenStack = "ipv5"; return r }(),
+		func() ForwardRule { r := base(); r.ListenAddr = "example.com"; return r }(),
+		func() ForwardRule { r := base(); r.ListenAddr = "999.1.1.1"; return r }(),
+	}
+	for i, r := range invalid {
+		if err := r.Validate(); err == nil {
+			t.Errorf("invalid[%d] expected error, got nil", i)
+		}
+	}
+}
+
+// TestAddRule_IPv4Only_SingleRelay verifies an explicit ipv4-only rule binds a
+// single TCP relay on the IPv4 wildcard (no multiRelay wrapper).
+func TestAddRule_IPv4Only_SingleRelay(t *testing.T) {
+	m := newTestManager(t)
+	defer m.Close()
+
+	created, err := m.AddRule(ForwardRule{
+		Username:    "v4@test.com",
+		TargetAddr:  "127.0.0.1:9",
+		ListenStack: ListenStackIPv4,
+	})
+	if err != nil {
+		t.Fatalf("AddRule ipv4: %v", err)
+	}
+	mr := m.rules[created.RuleKey()]
+	if _, ok := mr.relay.(*TCPRelay); !ok {
+		t.Fatalf("expected *TCPRelay, got %T", mr.relay)
+	}
+	if !relayServesPort(mr.relay, created.ListenPort) {
+		t.Errorf("listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	}
+}
+
+// TestAddRule_Dual_Default_MultiRelay verifies the default (unset) rule uses a
+// dual-stack multiRelay and that the IPv4 half is always up regardless of
+// whether the host can bind IPv6.
+func TestAddRule_Dual_Default_MultiRelay(t *testing.T) {
+	m := newTestManager(t)
+	defer m.Close()
+
+	created, err := m.AddRule(ForwardRule{
+		Username:   "dual@test.com",
+		TargetAddr: "127.0.0.1:9",
+	})
+	if err != nil {
+		t.Fatalf("AddRule dual: %v", err)
+	}
+	mr := m.rules[created.RuleKey()]
+	if _, ok := mr.relay.(*multiRelay); !ok {
+		t.Fatalf("expected *multiRelay, got %T", mr.relay)
+	}
+	if !relayServesPort(mr.relay, created.ListenPort) {
+		t.Errorf("dual listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	}
+}
+
+// TestAddRule_IPv6Only binds an explicit ipv6-only rule. Skipped on hosts that
+// cannot bind an IPv6 wildcard.
+func TestAddRule_IPv6Only(t *testing.T) {
+	if !ipv6WildcardBindable() {
+		t.Skip("host cannot bind an IPv6 wildcard listener")
+	}
+	m := newTestManager(t)
+	defer m.Close()
+
+	created, err := m.AddRule(ForwardRule{
+		Username:    "v6@test.com",
+		TargetAddr:  "127.0.0.1:9",
+		ListenStack: ListenStackIPv6,
+	})
+	if err != nil {
+		t.Fatalf("AddRule ipv6: %v", err)
+	}
+	mr := m.rules[created.RuleKey()]
+	if _, ok := mr.relay.(*TCPRelay); !ok {
+		t.Fatalf("expected *TCPRelay, got %T", mr.relay)
+	}
+	if !relayServesPort(mr.relay, created.ListenPort) {
+		t.Errorf("listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	}
+}

--- a/pkg/proxy/forward/listen_test.go
+++ b/pkg/proxy/forward/listen_test.go
@@ -1,20 +1,11 @@
 package forward
 
 import (
-	"fmt"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
 )
-
-// relayServesPort reports whether the relay's bound address(es) include port.
-// The wildcard IP form (0.0.0.0 vs [::]) is host-dependent — some namespaces
-// collapse an IPv4 wildcard bind onto a dual-stack IPv6 socket — so tests assert
-// on the port and relay type rather than the exact wildcard address string.
-func relayServesPort(r Relay, port uint32) bool {
-	return strings.Contains(r.ListenAddr(), fmt.Sprintf(":%d", port))
-}
 
 // assertUDPRelay asserts that r forwards over UDP, transparently unwrapping the
 // dual-stack *multiRelay (each child must itself be a *UDPRelay).
@@ -108,37 +99,49 @@ func TestResolveListenEndpoints(t *testing.T) {
 			want:       []listenEndpoint{{address: "[2001:db8::1]:8080"}},
 		},
 		{
+			name:       "explicit v4 wildcard literal is pinned to family 4",
+			listenAddr: "0.0.0.0",
+			port:       8080,
+			want:       []listenEndpoint{{address: "0.0.0.0:8080", family: "4"}},
+		},
+		{
+			name:       "explicit v6 wildcard literal is pinned to family 6",
+			listenAddr: "::",
+			port:       8080,
+			want:       []listenEndpoint{{address: "[::]:8080", family: "6"}},
+		},
+		{
 			name: "empty inherits default dual, both best-effort",
 			port: 9000,
 			want: []listenEndpoint{
-				{address: "0.0.0.0:9000", optional: true},
-				{address: "[::]:9000", v6only: true, optional: true},
+				{address: "0.0.0.0:9000", family: "4", optional: true},
+				{address: "[::]:9000", family: "6", optional: true},
 			},
 		},
 		{
 			name:      "rule ipv4 only",
 			ruleStack: ListenStackIPv4,
 			port:      9000,
-			want:      []listenEndpoint{{address: "0.0.0.0:9000"}},
+			want:      []listenEndpoint{{address: "0.0.0.0:9000", family: "4"}},
 		},
 		{
-			name:      "rule ipv6 only is v6only",
+			name:      "rule ipv6 only is family 6",
 			ruleStack: ListenStackIPv6,
 			port:      9000,
-			want:      []listenEndpoint{{address: "[::]:9000", v6only: true}},
+			want:      []listenEndpoint{{address: "[::]:9000", family: "6"}},
 		},
 		{
 			name:         "default ipv4 applies when rule unset",
 			defaultStack: ListenStackIPv4,
 			port:         9000,
-			want:         []listenEndpoint{{address: "0.0.0.0:9000"}},
+			want:         []listenEndpoint{{address: "0.0.0.0:9000", family: "4"}},
 		},
 		{
 			name:         "rule overrides default",
 			ruleStack:    ListenStackIPv6,
 			defaultStack: ListenStackIPv4,
 			port:         9000,
-			want:         []listenEndpoint{{address: "[::]:9000", v6only: true}},
+			want:         []listenEndpoint{{address: "[::]:9000", family: "6"}},
 		},
 		{
 			name:       "specific address ignores stack",
@@ -223,14 +226,16 @@ func TestAddRule_IPv4Only_SingleRelay(t *testing.T) {
 	if _, ok := mr.relay.(*TCPRelay); !ok {
 		t.Fatalf("expected *TCPRelay, got %T", mr.relay)
 	}
-	if !relayServesPort(mr.relay, created.ListenPort) {
-		t.Errorf("listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	// tcp4 forces a real AF_INET socket, so the bound address is 0.0.0.0
+	// (NOT promoted to a dual-stack [::] socket the way a bare "tcp" listen is).
+	if !strings.HasPrefix(mr.relay.ListenAddr(), "0.0.0.0:") {
+		t.Errorf("listen addr = %q, want 0.0.0.0:* (real AF_INET, not dual-stack)", mr.relay.ListenAddr())
 	}
 }
 
 // TestAddRule_Dual_Default_MultiRelay verifies the default (unset) rule uses a
-// dual-stack multiRelay and that the IPv4 half is always up regardless of
-// whether the host can bind IPv6.
+// dual-stack multiRelay whose IPv4 half is always up; on IPv6-capable hosts the
+// IPv6 half comes up too, as a separate socket.
 func TestAddRule_Dual_Default_MultiRelay(t *testing.T) {
 	m := newTestManager(t)
 	defer m.Close()
@@ -246,8 +251,12 @@ func TestAddRule_Dual_Default_MultiRelay(t *testing.T) {
 	if _, ok := mr.relay.(*multiRelay); !ok {
 		t.Fatalf("expected *multiRelay, got %T", mr.relay)
 	}
-	if !relayServesPort(mr.relay, created.ListenPort) {
-		t.Errorf("dual listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	addr := mr.relay.ListenAddr()
+	if !strings.Contains(addr, "0.0.0.0:") {
+		t.Errorf("dual listen addr = %q, want it to include the IPv4 wildcard", addr)
+	}
+	if ipv6WildcardBindable() && !strings.Contains(addr, "[::]:") {
+		t.Errorf("dual listen addr = %q, want it to include the IPv6 wildcard on an IPv6-capable host", addr)
 	}
 }
 
@@ -272,7 +281,7 @@ func TestAddRule_IPv6Only(t *testing.T) {
 	if _, ok := mr.relay.(*TCPRelay); !ok {
 		t.Fatalf("expected *TCPRelay, got %T", mr.relay)
 	}
-	if !relayServesPort(mr.relay, created.ListenPort) {
-		t.Errorf("listen addr = %q, want it to serve port %d", mr.relay.ListenAddr(), created.ListenPort)
+	if !strings.HasPrefix(mr.relay.ListenAddr(), "[::]:") {
+		t.Errorf("listen addr = %q, want [::]:* (tcp6, IPV6_V6ONLY)", mr.relay.ListenAddr())
 	}
 }

--- a/pkg/proxy/forward/port_allocator.go
+++ b/pkg/proxy/forward/port_allocator.go
@@ -30,6 +30,12 @@ type PortAllocatorConfig struct {
 	// UseRandom enables random port allocation instead of round-robin.
 	// Random allocation is recommended to avoid predictable port patterns.
 	UseRandom bool `yaml:"use_random" json:"use_random"`
+	// ListenStack is the default IP stack for wildcard forward listeners:
+	// "dual" (default, IPv4+IPv6), "ipv4", or "ipv6". This is carried in the
+	// forward config section and consumed by the ForwardManager; the port
+	// allocator itself ignores it. Individual rules override via
+	// ForwardRule.ListenStack.
+	ListenStack string `yaml:"listen_stack" json:"listen_stack"`
 }
 
 // NewPortAllocator creates a new PortAllocator.

--- a/pkg/proxy/forward/relay_multi.go
+++ b/pkg/proxy/forward/relay_multi.go
@@ -1,0 +1,76 @@
+package forward
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lureiny/v2raymg/pkg/log"
+)
+
+// relayChild is one member of a multiRelay together with its criticality.
+type relayChild struct {
+	relay    Relay
+	optional bool // best-effort: a Start failure is logged and skipped, not fatal
+}
+
+// multiRelay fans a single logical forward rule across multiple bound sockets
+// (e.g. an IPv4 wildcard plus an IPv6 wildcard for dual-stack listening). All
+// child relays share the rule's TrafficCounter and user-level limiters, so
+// counting and client limits behave as one rule regardless of which socket a
+// connection arrived on.
+//
+// It satisfies the Relay interface so DefaultForwardManager can store it in the
+// same single-relay slot as a plain TCP/UDP relay.
+type multiRelay struct {
+	children []relayChild
+	started  []Relay // children that started successfully (populated by Start)
+}
+
+func newMultiRelay(children []relayChild) *multiRelay {
+	return &multiRelay{children: children}
+}
+
+// Start starts each child in order. A required child failing rolls back every
+// already-started child and returns the error. An optional child failing is
+// logged and skipped (e.g. binding [::] on an IPv6-disabled host). Start
+// succeeds as long as at least one child came up.
+func (m *multiRelay) Start() error {
+	for _, c := range m.children {
+		if err := c.relay.Start(); err != nil {
+			if c.optional {
+				log.Warn("[ForwardManager] optional listener unavailable, skipping",
+					"addr", c.relay.ListenAddr(), "err", err)
+				continue
+			}
+			for _, s := range m.started {
+				s.Stop()
+			}
+			m.started = nil
+			return err
+		}
+		m.started = append(m.started, c.relay)
+	}
+	if len(m.started) == 0 {
+		return fmt.Errorf("no listener could be started")
+	}
+	return nil
+}
+
+// Stop stops every successfully-started child. Idempotent per child.
+func (m *multiRelay) Stop() {
+	for _, s := range m.started {
+		s.Stop()
+	}
+}
+
+// ListenAddr returns the comma-joined bound addresses of the started children.
+func (m *multiRelay) ListenAddr() string {
+	addrs := make([]string, 0, len(m.started))
+	for _, s := range m.started {
+		addrs = append(addrs, s.ListenAddr())
+	}
+	return strings.Join(addrs, ",")
+}
+
+// Compile-time interface conformance check.
+var _ Relay = (*multiRelay)(nil)

--- a/pkg/proxy/forward/relay_multi_test.go
+++ b/pkg/proxy/forward/relay_multi_test.go
@@ -1,0 +1,104 @@
+package forward
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeRelay is a controllable Relay for exercising multiRelay start/stop logic
+// without binding real sockets (so the IPv4-only / IPv6-only degradation paths
+// are testable on any host).
+type fakeRelay struct {
+	addr     string
+	startErr error
+	started  bool
+	stopped  bool
+}
+
+func (f *fakeRelay) Start() error {
+	if f.startErr != nil {
+		return f.startErr
+	}
+	f.started = true
+	return nil
+}
+func (f *fakeRelay) Stop()              { f.stopped = true }
+func (f *fakeRelay) ListenAddr() string { return f.addr }
+
+// IPv6-only host: the optional IPv4 half fails to bind, the IPv6 half succeeds,
+// and the rule still comes up on IPv6.
+func TestMultiRelay_IPv6OnlyHost(t *testing.T) {
+	v4 := &fakeRelay{addr: "0.0.0.0:9000", startErr: errors.New("cannot assign requested address")}
+	v6 := &fakeRelay{addr: "[::]:9000"}
+	mr := newMultiRelay([]relayChild{
+		{relay: v4, optional: true},
+		{relay: v6, optional: true},
+	})
+
+	if err := mr.Start(); err != nil {
+		t.Fatalf("Start should succeed when the IPv6 half binds: %v", err)
+	}
+	if v4.started {
+		t.Error("IPv4 half should not be marked started")
+	}
+	if !v6.started {
+		t.Error("IPv6 half should be started")
+	}
+	if got := mr.ListenAddr(); got != "[::]:9000" {
+		t.Errorf("ListenAddr = %q, want only the IPv6 address", got)
+	}
+	mr.Stop()
+	if !v6.stopped {
+		t.Error("Stop should stop the started IPv6 half")
+	}
+}
+
+// IPv4-only host: the optional IPv6 half fails, the IPv4 half succeeds.
+func TestMultiRelay_IPv4OnlyHost(t *testing.T) {
+	v4 := &fakeRelay{addr: "0.0.0.0:9000"}
+	v6 := &fakeRelay{addr: "[::]:9000", startErr: errors.New("address family not supported")}
+	mr := newMultiRelay([]relayChild{
+		{relay: v4, optional: true},
+		{relay: v6, optional: true},
+	})
+
+	if err := mr.Start(); err != nil {
+		t.Fatalf("Start should succeed when the IPv4 half binds: %v", err)
+	}
+	if got := mr.ListenAddr(); got != "0.0.0.0:9000" {
+		t.Errorf("ListenAddr = %q, want only the IPv4 address", got)
+	}
+}
+
+// Neither family can bind: the rule must fail.
+func TestMultiRelay_NoFamilyBinds(t *testing.T) {
+	v4 := &fakeRelay{addr: "0.0.0.0:9000", startErr: errors.New("boom4")}
+	v6 := &fakeRelay{addr: "[::]:9000", startErr: errors.New("boom6")}
+	mr := newMultiRelay([]relayChild{
+		{relay: v4, optional: true},
+		{relay: v6, optional: true},
+	})
+	if err := mr.Start(); err == nil {
+		t.Fatal("Start must fail when no endpoint binds")
+	}
+}
+
+// A required endpoint failing rolls back any already-started children.
+func TestMultiRelay_RequiredFailureRollsBack(t *testing.T) {
+	ok := &fakeRelay{addr: "0.0.0.0:9000"}
+	required := &fakeRelay{addr: "[::]:9000", startErr: errors.New("hard fail")}
+	mr := newMultiRelay([]relayChild{
+		{relay: ok, optional: true},
+		{relay: required, optional: false},
+	})
+	if err := mr.Start(); err == nil {
+		t.Fatal("Start must fail when a required endpoint fails")
+	}
+	if !ok.stopped {
+		t.Error("already-started child must be stopped on rollback")
+	}
+	if strings.TrimSpace(mr.ListenAddr()) != "" {
+		t.Errorf("ListenAddr should be empty after a failed Start, got %q", mr.ListenAddr())
+	}
+}

--- a/pkg/proxy/forward/relay_tcp.go
+++ b/pkg/proxy/forward/relay_tcp.go
@@ -28,7 +28,7 @@ const (
 type TCPRelay struct {
 	listenAddr string
 	targetAddr string
-	v6only     bool // set IPV6_V6ONLY on the listen socket
+	family     string // address-family network suffix: "" | "4" | "6"
 
 	counter     *TrafficCounter
 	limiterUp   Limiter // upload (client → target), nil = unlimited
@@ -48,12 +48,12 @@ type TCPRelay struct {
 // TCPRelayConfig configures a TCPRelay.
 type TCPRelayConfig struct {
 	ListenAddr    string
-	V6Only        bool // set IPV6_V6ONLY on the listen socket (IPv6 wildcard only)
+	Family        string // address-family network suffix: "" (tcp) | "4" (tcp4) | "6" (tcp6)
 	TargetAddr    string
 	Counter       *TrafficCounter
-	LimiterUp     Limiter // nil = no limit
-	LimiterDown   Limiter // nil = no limit
-	MaxConns      int     // 0 = unlimited
+	LimiterUp     Limiter       // nil = no limit
+	LimiterDown   Limiter       // nil = no limit
+	MaxConns      int           // 0 = unlimited
 	ClientLimiter ClientLimiter // nil = no client-level limit
 }
 
@@ -62,7 +62,7 @@ func NewTCPRelay(cfg TCPRelayConfig) *TCPRelay {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &TCPRelay{
 		listenAddr:    cfg.ListenAddr,
-		v6only:        cfg.V6Only,
+		family:        cfg.Family,
 		targetAddr:    cfg.TargetAddr,
 		counter:       cfg.Counter,
 		limiterUp:     cfg.LimiterUp,
@@ -76,7 +76,7 @@ func NewTCPRelay(cfg TCPRelayConfig) *TCPRelay {
 
 // Start begins listening and accepting connections.
 func (r *TCPRelay) Start() error {
-	ln, err := listenTCP(r.listenAddr, r.v6only)
+	ln, err := listenTCP(r.listenAddr, r.family)
 	if err != nil {
 		return fmt.Errorf("relay listen %s: %w", r.listenAddr, err)
 	}

--- a/pkg/proxy/forward/relay_tcp.go
+++ b/pkg/proxy/forward/relay_tcp.go
@@ -28,6 +28,7 @@ const (
 type TCPRelay struct {
 	listenAddr string
 	targetAddr string
+	v6only     bool // set IPV6_V6ONLY on the listen socket
 
 	counter     *TrafficCounter
 	limiterUp   Limiter // upload (client → target), nil = unlimited
@@ -47,6 +48,7 @@ type TCPRelay struct {
 // TCPRelayConfig configures a TCPRelay.
 type TCPRelayConfig struct {
 	ListenAddr    string
+	V6Only        bool // set IPV6_V6ONLY on the listen socket (IPv6 wildcard only)
 	TargetAddr    string
 	Counter       *TrafficCounter
 	LimiterUp     Limiter // nil = no limit
@@ -60,6 +62,7 @@ func NewTCPRelay(cfg TCPRelayConfig) *TCPRelay {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &TCPRelay{
 		listenAddr:    cfg.ListenAddr,
+		v6only:        cfg.V6Only,
 		targetAddr:    cfg.TargetAddr,
 		counter:       cfg.Counter,
 		limiterUp:     cfg.LimiterUp,
@@ -73,7 +76,7 @@ func NewTCPRelay(cfg TCPRelayConfig) *TCPRelay {
 
 // Start begins listening and accepting connections.
 func (r *TCPRelay) Start() error {
-	ln, err := net.Listen("tcp", r.listenAddr)
+	ln, err := listenTCP(r.listenAddr, r.v6only)
 	if err != nil {
 		return fmt.Errorf("relay listen %s: %w", r.listenAddr, err)
 	}

--- a/pkg/proxy/forward/relay_udp.go
+++ b/pkg/proxy/forward/relay_udp.go
@@ -40,6 +40,7 @@ const (
 type UDPRelay struct {
 	listenAddr string
 	targetAddr string
+	v6only     bool // set IPV6_V6ONLY on the listen socket
 
 	counter       *TrafficCounter
 	limiterUp     Limiter
@@ -63,6 +64,7 @@ type UDPRelay struct {
 // UDPRelayConfig configures a UDPRelay.
 type UDPRelayConfig struct {
 	ListenAddr         string
+	V6Only             bool // set IPV6_V6ONLY on the listen socket (IPv6 wildcard only)
 	TargetAddr         string
 	Counter            *TrafficCounter
 	LimiterUp          Limiter
@@ -81,6 +83,7 @@ func NewUDPRelay(cfg UDPRelayConfig) *UDPRelay {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &UDPRelay{
 		listenAddr:         cfg.ListenAddr,
+		v6only:             cfg.V6Only,
 		targetAddr:         cfg.TargetAddr,
 		counter:            cfg.Counter,
 		limiterUp:          cfg.LimiterUp,
@@ -116,7 +119,7 @@ type udpSession struct {
 // Calling Start twice will fail the second call at ListenPacket (address
 // already in use), matching TCPRelay's failure semantics.
 func (r *UDPRelay) Start() error {
-	pc, err := net.ListenPacket("udp", r.listenAddr)
+	pc, err := listenUDP(r.listenAddr, r.v6only)
 	if err != nil {
 		return fmt.Errorf("udp relay listen %s: %w", r.listenAddr, err)
 	}

--- a/pkg/proxy/forward/relay_udp.go
+++ b/pkg/proxy/forward/relay_udp.go
@@ -40,7 +40,7 @@ const (
 type UDPRelay struct {
 	listenAddr string
 	targetAddr string
-	v6only     bool // set IPV6_V6ONLY on the listen socket
+	family     string // address-family network suffix: "" | "4" | "6"
 
 	counter       *TrafficCounter
 	limiterUp     Limiter
@@ -64,7 +64,7 @@ type UDPRelay struct {
 // UDPRelayConfig configures a UDPRelay.
 type UDPRelayConfig struct {
 	ListenAddr         string
-	V6Only             bool // set IPV6_V6ONLY on the listen socket (IPv6 wildcard only)
+	Family             string // address-family network suffix: "" (udp) | "4" (udp4) | "6" (udp6)
 	TargetAddr         string
 	Counter            *TrafficCounter
 	LimiterUp          Limiter
@@ -83,7 +83,7 @@ func NewUDPRelay(cfg UDPRelayConfig) *UDPRelay {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &UDPRelay{
 		listenAddr:         cfg.ListenAddr,
-		v6only:             cfg.V6Only,
+		family:             cfg.Family,
 		targetAddr:         cfg.TargetAddr,
 		counter:            cfg.Counter,
 		limiterUp:          cfg.LimiterUp,
@@ -119,7 +119,7 @@ type udpSession struct {
 // Calling Start twice will fail the second call at ListenPacket (address
 // already in use), matching TCPRelay's failure semantics.
 func (r *UDPRelay) Start() error {
-	pc, err := listenUDP(r.listenAddr, r.v6only)
+	pc, err := listenUDP(r.listenAddr, r.family)
 	if err != nil {
 		return fmt.Errorf("udp relay listen %s: %w", r.listenAddr, err)
 	}

--- a/pkg/proxy/forward/types.go
+++ b/pkg/proxy/forward/types.go
@@ -11,6 +11,8 @@ package forward
 
 import (
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/lureiny/v2raymg/pkg/proxy/core/contracts"
 )
@@ -34,8 +36,18 @@ type ForwardRule struct {
 	// Protocol is the proxy protocol (e.g., "vless", "vmess", "trojan").
 	Protocol contracts.Protocol `json:"protocol"`
 
-	// ListenAddr is the address the relay listens on (default "0.0.0.0").
+	// ListenAddr is a SPECIFIC IP literal the relay binds to (IPv4 or IPv6).
+	// When set, exactly one socket is bound to that address and ListenStack is
+	// ignored (the address family decides the stack). When empty, a wildcard
+	// listener is bound according to ListenStack.
 	ListenAddr string `json:"listen_addr"`
+
+	// ListenStack selects which IP stack the WILDCARD listener binds when
+	// ListenAddr is empty: "ipv4" (0.0.0.0 only), "ipv6" ([::] only), or
+	// "dual" (both 0.0.0.0 and [::]). Empty inherits the ForwardManager's
+	// global default (which itself defaults to "dual"). Ignored when
+	// ListenAddr is a specific IP literal.
+	ListenStack string `json:"listen_stack,omitempty"`
 
 	// ListenPort is the port the relay listens on (assigned by PortAllocator).
 	// If 0, a port will be auto-allocated.
@@ -84,6 +96,17 @@ const (
 	NetworkUDP NetworkKind = "udp"
 )
 
+// Listen stack selectors for a wildcard forward listener.
+const (
+	// ListenStackDual binds both the IPv4 (0.0.0.0) and IPv6 ([::]) wildcard.
+	// This is the default when nothing is configured.
+	ListenStackDual = "dual"
+	// ListenStackIPv4 binds only the IPv4 wildcard (0.0.0.0).
+	ListenStackIPv4 = "ipv4"
+	// ListenStackIPv6 binds only the IPv6 wildcard ([::], IPV6_V6ONLY).
+	ListenStackIPv6 = "ipv6"
+)
+
 // ResolvedNetwork returns the transport for this rule, mapping the empty
 // string to TCP for backward compatibility.
 func (r *ForwardRule) ResolvedNetwork() NetworkKind {
@@ -107,6 +130,16 @@ func (r *ForwardRule) Validate() error {
 	}
 	if r.ListenPort != 0 && (r.ListenPort < 100 || r.ListenPort > 65535) {
 		return fmt.Errorf("forward rule: listen_port %d out of range [100, 65535]", r.ListenPort)
+	}
+	if r.ListenAddr != "" && net.ParseIP(r.ListenAddr) == nil {
+		return fmt.Errorf("forward rule: listen_addr %q must be a valid IP literal", r.ListenAddr)
+	}
+	switch strings.ToLower(strings.TrimSpace(r.ListenStack)) {
+	case "", ListenStackDual, ListenStackIPv4, ListenStackIPv6:
+		// ok
+	default:
+		return fmt.Errorf("forward rule: unsupported listen_stack %q (want %q, %q, or %q)",
+			r.ListenStack, ListenStackIPv4, ListenStackIPv6, ListenStackDual)
 	}
 	switch r.Network {
 	case "", string(NetworkTCP), string(NetworkUDP):


### PR DESCRIPTION
## What

Forward rules can now choose their listen IP stack, and the default changes from IPv4-only to **dual-stack** (listen on both IPv4 and IPv6).

- `ForwardRule.ListenAddr` binds a specific IP; IPv6 literals are now bracketed via `net.JoinHostPort` (fixes the old `"%s:%d"` corruption that made bare IPv6 addresses unbindable).
- `ForwardRule.ListenStack` selects `ipv4` / `ipv6` / `dual` for wildcard listeners.
- New global config `forward.listen_stack` (default `dual`) is the fallback when a rule doesn't set its own stack.
- `dual` binds `0.0.0.0` + `[::]` (via `tcp6` / `IPV6_V6ONLY` so both coexist on one port). **Both halves are best-effort**, so an IPv4-only host and an IPv6-only host each come up on the family they have; the rule fails only if neither binds. Explicit `ipv4`/`ipv6`/specific-IP remain hard requirements.
- `multiRelay` composite fans one rule across both sockets, sharing the traffic counter and user-level limiters.

## Upgrade behavior

Old configs (no `listen_stack` key) resolve to `dual` via two layers (`defaultAppConfig` + constructor guard), so an upgraded node with IPv6 available starts listening on IPv4+IPv6 with **no config change**.

## Tests

- `listen_test.go`: endpoint resolution table, `Validate()` for listen fields, single-stack vs dual `AddRule`.
- `relay_multi_test.go`: host-independent IPv4-only / IPv6-only degradation, "neither binds → fail", required-failure rollback.
- Full suite green locally.