### PR TITLE
feat(sub): log token→user resolution at debug level for /sub requests

### DIFF
--- a/pkg/http/sub_handler.go
+++ b/pkg/http/sub_handler.go
@@ -85,7 +85,7 @@ func (handler *SubHandler) handlerFunc(c *gin.Context) {
 		}
 		user := finder.FindUserByToken(token)
 		if user == nil {
-			log.Error("sub: invalid token", "target", parasMap["target"])
+			log.Error("sub: invalid token", "token", maskToken(token), "target", parasMap["target"])
 			c.String(200, "invalid user")
 			return
 		}
@@ -113,6 +113,19 @@ func (handler *SubHandler) handlerFunc(c *gin.Context) {
 		username = name
 		localUser = user
 	}
+
+	// Audit which credential resolved to which user. Emitted at debug level so
+	// it is off by default and can be switched on only while diagnosing (e.g.
+	// "the old token still works" reports). Tokens are proxy credentials, so
+	// only a masked prefix is logged — enough to tell an old (reset) token apart
+	// from the current one.
+	authMethod := "password"
+	if token != "" {
+		authMethod = "token"
+	}
+	log.Debug("[SubHandler] sub request authenticated",
+		"user", username, "auth", authMethod, "token", maskToken(token),
+		"target", parasMap["target"], "node", handler.getHttpServer().Name)
 
 	nodes := handler.getHttpServer().GetTargetNodes(parasMap["target"])
 	if nodes == nil {
@@ -292,6 +305,19 @@ func shouldEmitSubUserInfo(queryVal string, configDefault bool) bool {
 	default:
 		return configDefault
 	}
+}
+
+// maskToken returns a log-safe form of an auth token: a short prefix that lets
+// operators correlate requests (and tell a reset token apart from the current
+// one) without writing the full credential to logs. Empty in → empty out.
+func maskToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	if len(token) <= 8 {
+		return "****"
+	}
+	return token[:8] + "..."
 }
 
 func (handler *SubHandler) getHandlers() []gin.HandlerFunc {


### PR DESCRIPTION
## What

Adds a **debug-level** audit line to the subscription handler (`pkg/http/sub_handler.go`) recording, for every `/sub` request, which credential resolved to which user:

```
[SubHandler] sub request authenticated  user=alice auth=token token=269fb2c9... target=node1 node=hk-1
```

Fields: `user`, `auth` (token|password), masked `token` prefix, `target`, and the resolving `node`.

## Why

Investigating a "reset the token but the old token still works" report surfaced that the `/sub` success path logged **nothing** — there was no way to see which token mapped to which user, or which node did the resolving. The single-node reset logic itself is correct (old token stops resolving immediately); the missing observability is what made the report hard to diagnose (most likely a multi-node cluster-sync timing/config issue).

## Details

- Emitted at `log.Debug` so it is **off by default** and can be switched on only while diagnosing.
- New `maskToken` helper logs only a short prefix (tokens are proxy credentials) — enough to tell an old (reset) token apart from the current one when correlating with the token returned by `/user/reset-token`.
- The existing `sub: invalid token` error log now also carries the masked token.

## Test

`go build`, `go vet`, `go test ./pkg/http/` all pass.